### PR TITLE
Take cells-haml functions for form helpers

### DIFF
--- a/lib/cells/slim.rb
+++ b/lib/cells/slim.rb
@@ -30,7 +30,11 @@ module Cell
     # From FormTagHelper. why do they escape every possible string? why?
     def form_tag_in_block(html_options, &block)
       content = capture(&block)
-      "#{form_tag_html(html_options)}" << content << "</form>"
+      form_tag_with_body(html_options, content)
+    end
+
+    def form_tag_with_body(html_options, content)
+      "#{form_tag_html(html_options)}" << content.to_s << "</form>"
     end
 
     def form_tag_html(html_options)
@@ -38,6 +42,7 @@ module Cell
       "#{tag(:form, html_options, true) + extra_tags}"
     end
 
+    # Rails 4.0, TagHelper.
     def tag_option(key, value, escape)
       super(key, value, false)
     end


### PR DESCRIPTION
There were missing form helpers in cells-slim which make it not work (form_tag_with_body in particular). I just taken the one done in [cells-haml](https://github.com/trailblazer/cells-haml/blob/master/lib/cell/haml.rb#L59).
It still doesn't work very well (when viewing the form, '"' surrounds `<form>...</form>` and then it's displayed as a text and not as HTML code but I'll see later why it's like that (by comparing cells-haml and cells-slim)).
