### PR TITLE
fixed Cell::Slim#concat to return self

### DIFF
--- a/lib/cell/slim.rb
+++ b/lib/cell/slim.rb
@@ -64,6 +64,7 @@ module Cell
 
     def concat(string)
       @output_buffer << string
+      self
     end
   end
 end

--- a/test/slim_test.rb
+++ b/test/slim_test.rb
@@ -52,4 +52,10 @@ Bonjour!
 }.gsub("\n", "").gsub("  ", "")
   end
 
+  it 'allows concatenation chains' do
+    song_cell.capture do
+      song_cell.concat('Lorem').concat('ipsum')
+    end
+  end
+
 end


### PR DESCRIPTION
Original concat can be chained, this is used in some gems, for example boostrap_form
