### PR TITLE
Override different methods in Rails 5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.0.6
+
+* Rails 5.1 compatibility
+
 # 0.0.5
 
 * Restrict to Cells < 5.0.0.

--- a/lib/cell/slim/rails.rb
+++ b/lib/cell/slim/rails.rb
@@ -37,12 +37,12 @@ module Cell
         "#{tag(:form, html_options, true) + extra_tags}"
       end
 
-      def tag_options(options, escape = true)
-        super(options, true)
+      def tag(name = nil, options = nil, open = false, escape = true)
+        super(name, options, open, true)
       end
 
-      def content_tag_string(name, content, options, escape=true)
-        super(name, content, options, false)
+      def content_tag(name, content_or_options_with_block = nil, options = nil, escape = true, &block)
+        super(name, content_or_options_with_block, options, false, &block)
       end
 
       def concat(string)

--- a/lib/cell/slim/version.rb
+++ b/lib/cell/slim/version.rb
@@ -1,5 +1,5 @@
 module Cell
   module Slim
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end


### PR DESCRIPTION
In Rails 5.1 the methods `tag_options` and `content_tag_string` are defined on the new TagBuilder option, so the existing overrides don't work and blocks passed to helpers are escaped.

This PR instead overrides `tag` and `content_tag` which are the methods that call `tag_options` and `content_tag_string`

Example:

```
= link_to assignment_path(id) do
  span.grey-text Assignment ##{id}
```

Before:

`<a href="/assignments/123">&lt;span class="grey-text"&gt;Assignment #123 &lt;/span&gt;</a>`

After:

`<a href="/assignments/123"><span class="grey-text">Assignment #123</span></a>`
